### PR TITLE
Merchant revenue

### DIFF
--- a/app/controllers/api/v1/revenue/merchants_controller.rb
+++ b/app/controllers/api/v1/revenue/merchants_controller.rb
@@ -12,5 +12,12 @@ class Api::V1::Revenue::MerchantsController < ApplicationController
   end
 
   def show
+    # Check to see if param is an actual number; throws ArgumentError if not
+    converted_num = Integer params[:id]
+    # Check to see if params links to actual Merchant; throws RecordNotFound if not
+    Merchant.find(converted_num)
+    # Provided the above are valid, then return data
+    @merchant = Merchant.get_revenue_from(converted_num)
+    json_response(MerchantNameRevenueSerializer.new(@merchant))
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -17,7 +17,7 @@ class Merchant < ApplicationRecord
     # If merchant doesn't have revenue, still provide an output
     # This could turn into a helper method
     if merchant_and_revenue.nil?
-      Merchant.select("merchants.id, merchants.name, 0.00 as revenue").where("merchants.id = ?", id).first
+      Merchant.select("merchants.id, merchants.name, sum(0 + 0.00) as revenue").where("merchants.id = ?", id).first
     else
       merchant_and_revenue
     end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,7 +8,27 @@ class Merchant < ApplicationRecord
     Merchant.where("name ILIKE '%#{search_params}%'").limit(1).first
   end
 
+  def self.get_revenue_from(id)
+    merchant_and_revenue = Merchant.joins(:transactions)
+      .select("merchants.id, merchants.name, sum(invoice_items.unit_price * invoice_items.quantity) as revenue")
+      .where("merchants.id = ? AND invoices.status='shipped' AND transactions.result='success'", id)
+      .group('merchants.id').first
+
+    # If merchant doesn't have revenue, still provide an output
+    # This could turn into a helper method
+    if merchant_and_revenue.nil?
+      Merchant.select("merchants.id, merchants.name, 0.00 as revenue").where("merchants.id = ?", id).first
+    else
+      merchant_and_revenue
+    end
+  end
+
   def self.sort_by_revenue(quantity = 5)
-    Merchant.joins(:transactions).select("merchants.id, merchants.name, sum(invoice_items.unit_price * invoice_items.quantity) as revenue").where("invoices.status='shipped' AND transactions.result='success'").group('merchants.id').order('revenue DESC').limit(quantity)
+    Merchant.joins(:transactions)
+      .select("merchants.id, merchants.name, sum(invoice_items.unit_price * invoice_items.quantity) as revenue")
+      .where("invoices.status='shipped' AND transactions.result='success'")
+      .group('merchants.id')
+      .order('revenue DESC')
+      .limit(quantity)
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Merchant do
       revenue = Merchant.get_revenue_from(merchant.id)
 
       expect(revenue.name).to eq merchant.name
-      expect(revenue.revenue).to be_instance_of Float
+      expect(revenue.revenue).to be_a Float
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -41,5 +41,12 @@ RSpec.describe Merchant do
       expect(second_merchant.revenue).to be > bottom_merchant.revenue
     end
     
+    it 'returns one merchant and their revenue' do
+      merchant = Merchant.all.first
+      revenue = Merchant.get_revenue_from(merchant.id)
+
+      expect(revenue.name).to eq merchant.name
+      expect(revenue.revenue).to be_instance_of Float
+    end
   end
 end

--- a/spec/requests/revenue_spec.rb
+++ b/spec/requests/revenue_spec.rb
@@ -34,4 +34,31 @@ RSpec.describe 'Revenue endpoints' do
     end
   end
 
+  describe '/api/v1/revenue/merchants/:id' do
+    describe 'happy path' do
+      it 'returns a merchant with their revenue' do
+        merchant = Merchant.all.first
+        get "/api/v1/revenue/merchants/#{merchant.id}"
+
+        expect(response).to have_http_status 200
+        expect(json[:data][:attributes][:name]).to eq merchant.name
+        expect(json[:data][:attributes][:revenue]).to be_a Float
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns error if id is doesn\'t match db' do
+        get "/api/v1/revenue/merchants/90909"
+        
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns error if id is invalid' do
+        get "/api/v1/revenue/merchants/lolstrings"
+        
+        expect(response).to have_http_status 400
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Implements a functioning endpoint for `get /api/v1/revenue/merchants/:id`. There is a small deviation from the Postman tests, namely, their test wanted only revenue to be returned, but I also return the merchant's name as well.

**Small bug found:** The `/revenue/merchants` endpoint doesn't return the quantity provided if given a small enough dataset in the tests. For example, if a user requests a list of 10 but only 5 merchants actually have revenue, then only 5 are returned.