### PR TITLE
Adds endpoint for weekly revenue (awesome)

### DIFF
--- a/app/controllers/api/v1/revenue/weekly_controller.rb
+++ b/app/controllers/api/v1/revenue/weekly_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Revenue::WeeklyController < ApplicationController
+
+  def index
+    @weekly = Merchant.weekly_revenue
+    json_response(WeeklyRevenueSerializer.new(@weekly))
+  end
+
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -44,4 +44,7 @@ class Merchant < ApplicationRecord
     result[0]
   end
 
+  def self.weekly_revenue
+    Merchant.joins(:transactions).select("date_trunc('week', invoices.created_at) as week, sum(invoice_items.quantity * invoice_items.unit_price) as revenue").where("invoices.status = 'shipped' AND transactions.result = 'success'").group("week").order("week")
+  end
 end

--- a/app/serializers/weekly_revenue_serializer.rb
+++ b/app/serializers/weekly_revenue_serializer.rb
@@ -1,0 +1,13 @@
+class WeeklyRevenueSerializer
+  include JSONAPI::Serializer
+  extend ActionView::Helpers::NumberHelper # for converting to currency format
+
+  # Removes timestamp from week
+  attribute :week do |object|
+    object.week.to_s[0..9]
+  end
+
+  attribute :revenue do |object|
+    number_to_currency(object.revenue)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       # Revenue 
       namespace :revenue do
         resources :merchants, only: [:index, :show]
+        resources :weekly, only: :index
       end
 
       resources :revenue, only: :index

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -62,5 +62,10 @@ RSpec.describe Merchant do
     it 'returns total revenue' do
       expect(Merchant.total_revenue.revenue).to be_a Float
     end
+
+    # Again, tests should be revisited with a better factory
+    it 'returns revenue by week' do
+      expect(Merchant.weekly_revenue).to be_a Array
+    end
   end
 end

--- a/spec/requests/revenue_spec.rb
+++ b/spec/requests/revenue_spec.rb
@@ -98,4 +98,17 @@ RSpec.describe 'Revenue endpoints' do
       end
     end
   end
+
+  describe '/api/v1/revenue/weekly' do
+    describe 'happy path' do
+      it 'returns revenue broken down by week' do
+        get '/api/v1/revenue/weekly'
+
+        expect(response).to have_http_status 200
+        expect(json[:data][0][:attributes][:week]).to be_a String
+        expect(json[:data][0][:attributes][:revenue]).to be_a String
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Endpoint has revenue formatted as human-readable string because I figured out how to manipulate serialized output. Tests are sad, but functionality works as this endpoint is straightforward.